### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_hub_registry.yml
+++ b/.github/workflows/docker_hub_registry.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest CLI version and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.22
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "latest,cli,8.1"
@@ -24,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest Alpine version and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.22
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "alpine,8.1-alpine"
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest Apache version and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "apache,8.1-apache"
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} CLI and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: ${{ matrix.version }},${{ matrix.version }}-cli
@@ -69,7 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} Alpine and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug:${{ matrix.version }}-alpine
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} Apache and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug:${{ matrix.version }}-apache
           username: ${{ secrets.DOCKER_HUB_USERNAME }}

--- a/.github/workflows/github_container_registry.yml
+++ b/.github/workflows/github_container_registry.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest CLI version and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.22
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "latest,8.1"
@@ -27,7 +27,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest Alpine version and publish
-        uses: elgohr/Publish-Docker-Github-Action@2.22
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "alpine,8.1-alpine"
@@ -41,7 +41,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build latest Apache version and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: "apache,8.1-apache"
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} CLI and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug
           tags: ${{ matrix.version }},${{ matrix.version }}-cli
@@ -75,7 +75,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} Alpine and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug:${{ matrix.version }}-alpine
           username: mileschou
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Build PHP ${{ matrix.version }} Apache and publish
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: mileschou/xdebug:${{ matrix.version }}-apache
           username: mileschou


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore